### PR TITLE
revert unused changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,4 @@ dmypy.json
 .pyre/
 
 # Data downloads
-diffractionimaging/henke/*.nff
-diffractionimaging/henke/readme.txt
+./diffractionimaging/henke/*.nff

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# Data downloads
-./diffractionimaging/henke/*.nff

--- a/README.md
+++ b/README.md
@@ -13,15 +13,6 @@ cd diffractionimaging
 pip install --user -e .
 ```
 
-Download the recent atomic scattering factor data from
-```
-https://henke.lbl.gov/optical_constants/sf.tar.gz
-```
-and unzip the the content into subdirectory
-```
-./diffractionimaging/henke/
-```
-
 Test installation by running a python console somewhere else and execute
 ```python
 import diffractionimaging

--- a/diffractionimaging/henke/README.txt
+++ b/diffractionimaging/henke/README.txt
@@ -1,5 +1,0 @@
-Please download the atomic scattering factor data from
-
-    'https://henke.lbl.gov/optical_constants/sf.tar.gz'
-
-and extract the content into this folder.


### PR DESCRIPTION
the documentation contains information about data to download which is never used. this is unnecessary and misleading for installing the package. therefore remove it.

This is discussed in #6 