### PR TITLE
Fix: `np.bool` is deprecated since numpy 1.20. Use built-in `bool` instead

### DIFF
--- a/diffractionimaging/correlations.py
+++ b/diffractionimaging/correlations.py
@@ -59,7 +59,7 @@ def lru_cache_bool(maxlen=1):
 
         @functools.wraps(f)
         def ret(img):
-            if not img.dtype == np.bool:
+            if not img.dtype == bool:
                 # print('no cache')
                 # kein Caching
                 return f(img)


### PR DESCRIPTION
as suggested here https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations